### PR TITLE
website subpages

### DIFF
--- a/websiteV2/src/App.js
+++ b/websiteV2/src/App.js
@@ -40,7 +40,7 @@ const styles = {
 function App(props) {
   return (
     <div className={props.classes.application}>
-      <Router>
+      <Router basename="/v2">
         <div className={props.classes.topBar}>
           <MenuBar/>
         </div>

--- a/websiteV2/src/App.js
+++ b/websiteV2/src/App.js
@@ -34,6 +34,7 @@ const styles = {
     display: 'flex',
     width: '100%',
     height: '100%',
+    overflow: 'scroll',
   },
 };
 

--- a/websiteV2/src/components/DeveloperProfile.js
+++ b/websiteV2/src/components/DeveloperProfile.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import oldLogo from '../assets/oldLogo.png';
+import { withStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+
+const styles = {
+    devContainer: {
+        backgroundColor: '#424242',
+        margin: '10px',
+        width: '20%',
+        height: '30%',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        flexDirection: 'column',
+        color: 'white',
+    },
+    logo: {
+        width: '30%',
+    },
+};
+
+class DeveloperProfile extends React.Component {
+    render() {
+        return(
+            <div className={this.props.classes.devContainer}>
+                <img src={oldLogo} alt='SeeShells Logo' className={this.props.classes.logo}/>
+                <Typography variant="subtitle1">{this.props.name}</Typography>
+                <Typography variant="subtitle2">{this.props.role}</Typography>
+            </div>
+        );
+    }
+}
+
+export default withStyles(styles)(DeveloperProfile);

--- a/websiteV2/src/components/MenuBar.js
+++ b/websiteV2/src/components/MenuBar.js
@@ -52,7 +52,7 @@ class MenuBar extends React.Component {
     }
 
     handleClick(event) {
-        this.props.history.push("/" + event.currentTarget.id);
+        this.props.history.push(event.currentTarget.id);
     }
 
     render() {

--- a/websiteV2/src/components/MenuBar.js
+++ b/websiteV2/src/components/MenuBar.js
@@ -52,12 +52,12 @@ class MenuBar extends React.Component {
     }
 
     handleClick(event) {
-        this.props.history.push(event.currentTarget.id);
+        this.props.history.push("/" + event.currentTarget.id);
     }
 
     render() {
         return(
-            <Router>
+            <Router basename="/v2">
                 <div className={this.props.classes.menuBar}>
                     <img src={oldLogo} alt='SeeShells Logo' className={this.props.classes.logo} onClick={this.handleClick}/>
                     <p className={this.props.classes.title}>SEESHELLS</p>

--- a/websiteV2/src/components/SideBar.js
+++ b/websiteV2/src/components/SideBar.js
@@ -3,6 +3,14 @@ import { withStyles } from '@material-ui/core/styles';
 import { withRouter, BrowserRouter as Router } from 'react-router-dom';
 
 const styles = {
+    sidebarContainer: {
+        width: '20%',
+        height: '100%',
+        backgroundColor: '#424242',
+        margin: '0px',
+        display: 'flex',
+        justifyContent: 'center',
+    },
 };
 
 class SideBar extends React.Component {
@@ -19,7 +27,9 @@ class SideBar extends React.Component {
     render() {
         return(
             <Router>
-
+                <div className={this.props.classes.sidebarContainer}>
+                    <p> ajksdhga9dughaidgahugikahksjghasjkg</p>
+                </div>
             </Router>
         );
     }

--- a/websiteV2/src/containers/AboutPage.js
+++ b/websiteV2/src/containers/AboutPage.js
@@ -1,14 +1,25 @@
 import React from 'react';
+import SideBar from '../components/SideBar.js';
 import { withStyles } from '@material-ui/core/styles';
 import { withRouter } from 'react-router-dom';
 
 const styles = {
+    aboutPage: {
+        display: 'flex',
+        height: '100%',
+        width: '100%',
+    },
+    sidebar: {
+        float: 'left',
+    },
 };
 
 class AboutPage extends React.Component {
     render() {
         return(
-            <p>placeholder</p>
+            <div className={this.props.classes.aboutPage}>
+                <SideBar className={this.props.classes.sidebar}/>
+            </div>
         );
     }
 }

--- a/websiteV2/src/containers/DeveloperPage.js
+++ b/websiteV2/src/containers/DeveloperPage.js
@@ -1,14 +1,61 @@
 import React from 'react';
+import DeveloperProfile from '../components/DeveloperProfile.js';
 import { withStyles } from '@material-ui/core/styles';
 import { withRouter } from 'react-router-dom';
+import Typography from '@material-ui/core/Typography';
 
 const styles = {
+    devContainer: {
+        display: 'flex',
+        flexFlow: 'column',
+        justifyContent: 'center',
+        alignContent: 'center',
+        width: '100%',
+    },
+    dev: {
+        display: 'flex',
+        height: '90%',
+        justifyContent: 'space-evenly',
+        flexWrap: 'wrap',
+    },
+    devIntro: {
+        display: 'flex',
+        justifyContent: 'center',
+        flexDirection: 'column',
+        alignItems: 'center',
+    },
+    title: {
+        fontSize: '50px',
+        fontWeight: 'bold',
+        marginTop: '1%',
+        alignSelf: 'center',
+    },
 };
 
 class DeveloperPage extends React.Component {
     render() {
         return(
-            <p>placeholder</p>
+            <div className={this.props.classes.devContainer}>
+                <div className={this.props.classes.devIntro}>
+                    <Typography variant="title" className={this.props.classes.title}>SeeShells Development Teams</Typography>
+                    <Typography variant="subtitle1">
+                        The SeeShells application is a Senior Design project built by two teams of five Computer Science students at UCF.
+                        The V1 team designed the original application, while the V2 team enhanced the project.
+                    </Typography>
+                </div>
+                <div className={this.props.classes.dev}>
+                    <DeveloperProfile name="Sara Frackiewicz" role="V1 Team: API, Scripting, and Administrative Website"/>
+                    <DeveloperProfile name="Klayton Killough" role="V1 Team: WPF Shellbag Parser and IO"/>
+                    <DeveloperProfile name="Aleksandar Stoyanov" role="V1 Team: WPF Shellbag Parser and Timeline"/>
+                    <DeveloperProfile name="Bridget Woodye" role="V1 Team: WPF GUI and Timeline"/>
+                    <DeveloperProfile name="Yara As-Saidi" role="V1 Team: WPF and Website Content"/>
+                    <DeveloperProfile name="Devon Gadarowski" role="V2 Team:"/>
+                    <DeveloperProfile name="Kaylee Hoyt" role="V2 Team: Website Developer"/>
+                    <DeveloperProfile name="Jake Meyer" role="V2 Team:"/>
+                    <DeveloperProfile name="Spencer Ross" role="V2 Team:"/>
+                    <DeveloperProfile name="Joshua Rueda" role="V2 Team:"/>
+                </div>
+            </div>
         );
     }
 }

--- a/websiteV2/src/containers/DocumentationPage.js
+++ b/websiteV2/src/containers/DocumentationPage.js
@@ -1,14 +1,25 @@
 import React from 'react';
+import SideBar from '../components/SideBar.js';
 import { withStyles } from '@material-ui/core/styles';
 import { withRouter } from 'react-router-dom';
 
 const styles = {
+    documentationPage: {
+        display: 'flex',
+        height: '100%',
+        width: '100%',
+    },
+    sidebar: {
+        float: 'left',
+    },
 };
 
 class DocumentationPage extends React.Component {
     render() {
         return(
-            <p>placeholder</p>
+            <div className={this.props.classes.documentationPage}>
+                <SideBar className={this.props.classes.sidebar}/>
+            </div>
         );
     }
 }

--- a/websiteV2/src/containers/DownloadPage.js
+++ b/websiteV2/src/containers/DownloadPage.js
@@ -4,6 +4,13 @@ import { withStyles } from '@material-ui/core/styles';
 import { withRouter } from 'react-router-dom';
 
 const styles = {
+    downloadPage: {
+        display: 'flex',
+        flexFlow: 'column wrap',
+        justifyContent: 'center',
+        height: '100%',
+        width: '100%',
+    },
     image: {
         display: 'flex',
         width: '100%',
@@ -75,10 +82,12 @@ const styles = {
 class DownloadPage extends React.Component {
     render() {
         return(
-            <div className={this.props.classes.downloadContainer}>
-                <div className={this.props.classes.image}/>
-                <div className={this.props.classes.login}>
-                    <p className={this.props.classes.title}>Download SeeShells</p>
+            <div className={this.props.classes.downloadPage}>
+                <div className={this.props.classes.downloadContainer}>
+                    <div className={this.props.classes.image}/>
+                    <div className={this.props.classes.login}>
+                        <p className={this.props.classes.title}>Download SeeShells</p>
+                    </div>
                 </div>
             </div>
         );

--- a/websiteV2/src/containers/FrontPage.js
+++ b/websiteV2/src/containers/FrontPage.js
@@ -121,7 +121,7 @@ class FrontPage extends React.Component {
     }
 
     handleClick(event) {
-        this.props.history.push("/" + event.currentTarget.id);
+        this.props.history.push(event.currentTarget.id);
     }
 
     render() {

--- a/websiteV2/src/containers/FrontPage.js
+++ b/websiteV2/src/containers/FrontPage.js
@@ -121,12 +121,12 @@ class FrontPage extends React.Component {
     }
 
     handleClick(event) {
-        this.props.history.push(event.currentTarget.id);
+        this.props.history.push("/" + event.currentTarget.id);
     }
 
     render() {
         return(
-            <Router>
+            <Router basename="/v2">
                 <div className={this.props.classes.frontPage}>
                     <div className={this.props.classes.image}>
                         <div className={this.props.classes.barContent}>


### PR DESCRIPTION
this PR sets up all pages other than the front page and the admin page. it fixes some routing issues that were going on with github pages, as well

how to test:
- locally: npm install and npm start within the websitev2 folder
- remote: https://shellbags.github.io/v2/
- check all page redirects (front page buttons, all top menu bar buttons) to ensure they go to the appropriate pages (all urls should be in the format /v2/[pagename]


known bugs:
- resizing is really bad :')
- for some reason the sidebar on the about and documentation pages don't reach the bottom of the content div. i'm working on figuring out why that is